### PR TITLE
Feat/03 用戶用API瀏覽購買過的課程

### DIFF
--- a/app/api/course_store/entities/category.rb
+++ b/app/api/course_store/entities/category.rb
@@ -3,7 +3,7 @@ module CourseStore
     class Category < Grape::Entity
 
       expose :name, as: :categary_name
-      
+
     end
   end
 end

--- a/app/api/course_store/entities/category.rb
+++ b/app/api/course_store/entities/category.rb
@@ -1,9 +1,9 @@
 module CourseStore
   module Entities
-
     class Category < Grape::Entity
-      expose :name, as: :categary_name
-    end
 
+      expose :name, as: :categary_name
+      
+    end
   end
 end

--- a/app/api/course_store/entities/category.rb
+++ b/app/api/course_store/entities/category.rb
@@ -1,0 +1,9 @@
+module CourseStore
+  module Entities
+
+    class Category < Grape::Entity
+      expose :name, as: :categary_name
+    end
+
+  end
+end

--- a/app/api/course_store/entities/course.rb
+++ b/app/api/course_store/entities/course.rb
@@ -1,0 +1,18 @@
+module CourseStore
+  module Entities
+
+    class Course < Grape::Entity
+      expose :id
+      expose :topic
+      expose :price
+      expose :currency
+      expose :is_available
+      expose :content
+      expose :validity_period
+      expose :category, merge: true, using: CourseStore::Entities::Category
+      expose :url
+      expose :purchase_records, using: CourseStore::Entities::PurchaseRecord
+    end
+
+  end
+end

--- a/app/api/course_store/entities/course.rb
+++ b/app/api/course_store/entities/course.rb
@@ -1,8 +1,7 @@
 module CourseStore
   module Entities
-
     class Course < Grape::Entity
-      expose :id
+
       expose :topic
       expose :price
       expose :currency
@@ -12,7 +11,7 @@ module CourseStore
       expose :category, merge: true, using: CourseStore::Entities::Category
       expose :url
       expose :purchase_records, using: CourseStore::Entities::PurchaseRecord
+      
     end
-
   end
 end

--- a/app/api/course_store/entities/course.rb
+++ b/app/api/course_store/entities/course.rb
@@ -11,7 +11,7 @@ module CourseStore
       expose :category, merge: true, using: CourseStore::Entities::Category
       expose :url
       expose :purchase_records, using: CourseStore::Entities::PurchaseRecord
-      
+
     end
   end
 end

--- a/app/api/course_store/entities/purchase_record.rb
+++ b/app/api/course_store/entities/purchase_record.rb
@@ -1,0 +1,6 @@
+module CourseStore
+  module Entities
+     class PurchaseRecord < Grape::Entity
+   
+    end
+  end

--- a/app/api/course_store/entities/purchase_record.rb
+++ b/app/api/course_store/entities/purchase_record.rb
@@ -1,15 +1,20 @@
 module CourseStore
   module Entities
     class PurchaseRecord < Grape::Entity
-      expose :id
-      expose :user_id
-      expose :p_topic
+      
+      format_with(:datetime) do |time|
+        time.to_s(:db) 
+      end
+
       expose :p_price
       expose :p_currency
-      expose :p_category
       expose :p_validity_period
-      expose :purchase_date
-      expose :expiry_date
+
+      with_options(format_with: :datetime) do
+        expose :purchase_date
+        expose :expiry_date
+      end
+
     end
   end
 end

--- a/app/api/course_store/entities/purchase_record.rb
+++ b/app/api/course_store/entities/purchase_record.rb
@@ -1,6 +1,15 @@
 module CourseStore
   module Entities
-     class PurchaseRecord < Grape::Entity
-   
+    class PurchaseRecord < Grape::Entity
+      expose :id
+      expose :user_id
+      expose :p_topic
+      expose :p_price
+      expose :p_currency
+      expose :p_category
+      expose :p_validity_period
+      expose :purchase_date
+      expose :expiry_date
     end
   end
+end

--- a/app/api/course_store/entities/purchase_record.rb
+++ b/app/api/course_store/entities/purchase_record.rb
@@ -6,9 +6,9 @@ module CourseStore
         time.to_s(:db) 
       end
 
-      expose :p_price
-      expose :p_currency
-      expose :p_validity_period
+      expose :p_price, as: :purchase_price
+      expose :p_currency, as: :purchase_currency
+      expose :p_validity_period, as: :purchase_validity_period
 
       with_options(format_with: :datetime) do
         expose :purchase_date

--- a/app/api/course_store/v1/purchase_records.rb
+++ b/app/api/course_store/v1/purchase_records.rb
@@ -29,36 +29,35 @@ module CourseStore
 
       resource :purchase_records do
         desc 'Create a purchase record'
-        route_param :url do
-        # params do
-        #   requires :url, type: String
-        # end      
-          post do
-            course = Course.find_by!(url: params[:url])
-            last_purchase = PurchaseRecord.where(user_id: current_user.id, course_id: course.id ).last
+        params do
+          requires :url, type: String
+        end
 
-            if not last_purchase != nil && Time.now < last_purchase.expiry_date 
-              if course.is_available?
+        post do
+          course = Course.find_by!(url: params[:url])
+          last_purchase = PurchaseRecord.where(user_id: current_user.id, course_id: course.id ).last
 
-                PurchaseRecord.create!({
-                  user_id: current_user.id,
-                  course_id: course.id,
-                  p_topic: course.topic,
-                  p_price: course.price,
-                  p_currency: course.currency,
-                  p_category:  course.category.name,
-                  p_validity_period: course.validity_period,
-                  purchase_date: Time.now,
-                  expiry_date: Time.now + course.validity_period.day
-                })
+          if not last_purchase != nil && Time.now < last_purchase.expiry_date 
+            if course.is_available?
 
-              else
-                { message: 'The course is not available.', status: 406 }
-              end
+              PurchaseRecord.create!({
+                user_id: current_user.id,
+                course_id: course.id,
+                p_topic: course.topic,
+                p_price: course.price,
+                p_currency: course.currency,
+                p_category:  course.category.name,
+                p_validity_period: course.validity_period,
+                purchase_date: Time.now,
+                expiry_date: Time.now + course.validity_period.day
+              })
 
             else
-              { message: 'You still have this course that has not expired.', status: 406 }
+              { message: 'The course is not available.', status: 406 }
             end
+
+          else
+            { message: 'You still have this course that has not expired.', status: 406 }
           end
         end
 

--- a/app/api/course_store/v1/purchase_records.rb
+++ b/app/api/course_store/v1/purchase_records.rb
@@ -15,21 +15,13 @@ module CourseStore
         end
 
         def authenticated
-          if warden.authenticated?
-            return true
-          elsif params[:access_token] and
-              User.find_for_token_authentication("access_token" => params[:access_token])
-            return true
-          elsif params[:xapp_token] and
-              AccessGrant.find_access(params[:xapp_token])
-            return true
-          else
+         unless warden.authenticated?
             error!('401 Unauthorized', 401)
           end
         end
 
         def current_user
-          warden.user || User.find_for_token_authentication("access_token" => params[:access_token])
+          warden.user
         end
       end
 
@@ -41,7 +33,7 @@ module CourseStore
         # params do
         #   requires :url, type: String
         # end      
-          get do
+          post do
             course = Course.find_by!(url: params[:url])
             last_purchase = PurchaseRecord.where(user_id: current_user.id, course_id: course.id ).last
 

--- a/app/api/course_store/v1/purchase_records.rb
+++ b/app/api/course_store/v1/purchase_records.rb
@@ -87,7 +87,7 @@ module CourseStore
           
           a_u = a.uniq
 
-          present a_u
+          present a_u, with: CourseStore::Entities::Course
         end
       end
     end

--- a/app/api/course_store/v1/purchase_records.rb
+++ b/app/api/course_store/v1/purchase_records.rb
@@ -75,16 +75,14 @@ module CourseStore
         desc 'Purchase records of a user'
 
         get do
-          p current_user
-          p current_user.id
-          # purchase_records = PurchaseRecord.where(user_id: current_user.id).includes(:course)
-          purchase_records = current_user.purchase_records.includes(:course)
+
+          purchase_records = current_user.purchase_records.includes(course: :category)
           
           a = []
           purchase_records.each do |p|
             a << p.course
           end
-          
+
           a_u = a.uniq
 
           present a_u, with: CourseStore::Entities::Course

--- a/app/api/course_store/v1/purchase_records.rb
+++ b/app/api/course_store/v1/purchase_records.rb
@@ -74,43 +74,30 @@ module CourseStore
         desc 'Purchase records of a user'
         params do
           optional :category, type: String
-          optional :is_available?, type: Boolean
+          optional :valid, type: Boolean
         end
 
         get do
-          p '---------------------------------'
-          if params[:category].present?
-            ccc = Category.find_by!(name: params[:category]).id
+
+          if params[:category]
+            cc_id = Category.find_by!(name: params[:category]).id
           end
-          # p ccc
-          p params[:is_available?].present? 
-          # if params[:category].present? && Category.exists?(name: params[:category])
-          
-          p '---------------------------------'
-          # category = Category.find_by(name: params[:category])
          
           purchase_records = current_user.purchase_records.includes(course: :category)
           
-          # if p.course.category.name == params[:category]
-
-          # courses_list = []
-          # purchase_records.each do |p|
-          #   courses_list << p.course
-          # end
-
+        
           courses_list = purchase_records.map{ |x| x.course }
 
-          if params[:category] && params[:is_available?]
-            course_list = courses_list.uniq.select{ |x| x.category_id == ccc && x.is_available? && Time.now < x.purchase_records.last.expiry_date}
+          if params[:category] && params[:valid]
+            course_list = courses_list.uniq.select{ |x| x.category_id == cc_id && Time.now < x.purchase_records.last.expiry_date}
           elsif params[:category]
-            course_list = courses_list.uniq.select{ |x| x.category_id == ccc }
-          elsif params[:is_available?]
-            course_list = courses_list.uniq.select{ |x| x.is_available? && Time.now < x.purchase_records.last.expiry_date }
+            course_list = courses_list.uniq.select{ |x| x.category_id == cc_id }
+          elsif params[:valid]
+            course_list = courses_list.uniq.select{ |x| Time.now < x.purchase_records.last.expiry_date }
           else
             course_list = courses_list.uniq
           end
           
-
           present course_list, with: CourseStore::Entities::Course
         end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,7 @@ module OnlineCourse
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Taipei"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end


### PR DESCRIPTION
題目

- 回傳結果包含課程基本資料
- 回傳結果包含所有跟該課程相關的付款資料
- 可以用過濾方式找出特定類型的課程
- 可以用過濾方式找出目前可以上的課程

本分支內容

- 使用 entity 來管理資料輸出格式
- 專案時區調整，讓訂單顯示時間為 UTC +8
- API 回傳用戶購買過的課程資訊，及每個課程的付款紀錄、有效時間
- API 可依照類型篩選購買過的課程及目前還可以上的課程
- 上一支分支的 API 改為 post

現在兩支 API 路徑如下
<img width="858" alt="截圖 2022-02-17 下午3 11 47" src="https://user-images.githubusercontent.com/92938134/154424258-63eb5e6a-1f38-4454-8a12-1ecd642a2872.png">

1. 購買課程的API
```
key: url
value: 該課程伺服器之後的網址
```
2. 取得購買課程的 API
- 不輸入key&Value -> 得到該用戶所有購買資料
- 輸入  `key: category     value: 該類型中文字串` -> 篩選某類型課程的購買資料
- 輸入 `key: valid    value: true` -> 篩選還可以上的課程 
- 輸入 以上兩種 key -> 篩選某類型且還可以上的課程